### PR TITLE
Bug/check workspace id in sensor update

### DIFF
--- a/custom_components/toggl_track/manifest.json
+++ b/custom_components/toggl_track/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "lib-toggl==0.1.4"
   ],
-  "version": "0.0.1"
+  "version": "0.0.2"
 }


### PR DESCRIPTION
This should fix https://github.com/kquinsland/ha-toggl-track/issues/5

When data comes back from coordinator, check if the time entry workspace ID matches $self workspace ID.
