### PR TITLE
bump `lib-toggl` dependency to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ Any issues with the Toggl API should be reported to the [lib-toggl](https://gith
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Toggl Track for Home Assistant](#toggl-track-for-home-assistant)
-  - [TODOs](#todos)
-  - [Installation](#installation)
-    - [HACS](#hacs)
-    - [Manual](#manual)
-  - [Using](#using)
-    - [Sensors](#sensors)
-    - [Services](#services)
-      - [`toggl_track.new_time_entry`](#toggl_tracknew_time_entry)
-      - [`toggl_track.stop_time_entry`](#toggl_trackstop_time_entry)
+- [TODOs](#todos)
+- [Installation](#installation)
+  - [HACS](#hacs)
+  - [Manual](#manual)
+- [Using](#using)
+  - [Sensors](#sensors)
+  - [Services](#services)
+    - [`toggl_track.new_time_entry`](#toggl_tracknew_time_entry)
+    - [`toggl_track.stop_time_entry`](#toggl_trackstop_time_entry)
+    - [`toggl_track.edit_time_entry`](#toggl_trackedit_time_entry)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/custom_components/toggl_track/manifest.json
+++ b/custom_components/toggl_track/manifest.json
@@ -15,7 +15,7 @@
   ],
   "name": "Toggl Track",
   "requirements": [
-    "lib-toggl==0.1.5"
+    "lib-toggl==0.1.6"
   ],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,8 +27,11 @@ Basically mount the custom_components folder into the home assistant dev contain
 
 Then just install updated `lib-toggl` directly into the dev container via the terminal:
 
+> [!IMPORTANT]
+> When manually / locally installing the `lib-toggl` library, honor the `package_constraints.txt` file in the `homeassistant` folder to mimic a production install!
+
 ```shell
-vscode ➜ /workspaces/ha-core (add-toggl-track) $ pip install /workspaces/ha-core/config/custom_libraries/lib-toggl
+vscode ➜ / $ pip install /workspaces/core/config/custom_libraries/lib-toggl --upgrade --constraint /workspaces/core/homeassistant/package_constraints.txt
 ```
 
 You can then edit the `lib-toggl` library from the same context as the rest of the Home Assistant code base.


### PR DESCRIPTION
That version has correct pattern to import from Pydantic v2 and fall back to v1.

Added note to dev docs to explicitly cover how to install with constraints when working locally with the dev container. Previously, was not including constraints which resulted in latest pydantic v2 being installed. Didn't run into any issues because I was not using any of the other components that still depend on v1.


---

Depends on https://github.com/kquinsland/lib-toggl/pull/9